### PR TITLE
feat: 로그아웃, 그룹관리 admin

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const usersRouter = require("./routes/users");
 const signupRouter = require("./routes/signup");
 const loginRouter = require("./routes/login");
 const groupsRouter = require("./routes/groups");
+const logoutRouter = require("./routes/logout");
 
 const connectMongoDB = require("./configs/connectMongoDB");
 const passportConfig = require("./configs/passportConfig");
@@ -41,6 +42,7 @@ app.use("/login", loginRouter);
 // app.use(passport.authenticate("jwt", { session: false }));
 app.use("/users", usersRouter);
 app.use("/groups", groupsRouter);
+app.use("/logout", logoutRouter);
 
 app.use(function (req, res, next) {
   next(createError(404));

--- a/models/User.js
+++ b/models/User.js
@@ -13,6 +13,7 @@ const userSchema = new mongoose.Schema({
   groups: [
     {
       groupId: { type: mongoose.Schema.Types.ObjectId, ref: "Group" },
+      groupName: { type: String },
       status: {
         type: String,
         enum: ["PARTICIPATING", "PENDING", "REJECTED"],

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -1,0 +1,14 @@
+const espress = require("express");
+const router = espress.Router();
+
+router.post("/", function (req, res, next) {
+  req.logout((err) => {
+    if (err) {
+      return next(err);
+    }
+
+    res.redirect("/login");
+  });
+});
+
+module.exports = router;

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -1,13 +1,15 @@
 const espress = require("express");
 const router = espress.Router();
 
+const ERROR = require("../constants/error");
+
 router.post("/", function (req, res, next) {
   req.logout((err) => {
     if (err) {
-      return next(err);
+      return res.send(createError(400, ERROR.NO_ACCOUNT));
     }
 
-    res.redirect("/login");
+    return res.status(200).redirect("/login");
   });
 });
 

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -9,7 +9,7 @@ router.post("/", function (req, res, next) {
       return res.send(createError(400, ERROR.NO_ACCOUNT));
     }
 
-    return res.status(200).redirect("/login");
+    return res.sendStatus(200);
   });
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -9,9 +9,9 @@ const ERROR = require("../constants/error");
 
 router.get("/:user_id", async function (req, res, next) {
   const { user_id } = req.params;
-
   const userInfo = await User.findById(user_id);
-  res.status(200).json({ userInfo });
+
+  res.status(200).json(userInfo);
 });
 
 router.get("/:user_id/groups", async function (req, res, next) {
@@ -24,13 +24,18 @@ router.get("/:user_id/groups", async function (req, res, next) {
     }
 
     if (userInfo.role === "ADMIN") {
-      const group = await Group.findOne({ admin: user._id });
+      const applicants = await Group.findOne({ admin: user_id }).populate(
+        "applicants"
+      );
+      const memebers = await Group.findOne({ admin: user_id }).populate(
+        "members"
+      );
 
-      return res.status(200).json(group);
+      return res.status(200).json({ applicants, memebers });
     }
 
     if (userInfo.role === "MEMBER") {
-      res.json(user.groups);
+      return res.json(userInfo.groups);
     }
 
     return res.status(200).send(userInfo.groups);
@@ -76,7 +81,7 @@ router.post("/:user_id/groups/:group_id", async function (req, res, next) {
   }
 
   try {
-    await Group.findOneAndUpdate(
+    const group = await Group.findOneAndUpdate(
       { _id: groupId },
       {
         $push: {
@@ -91,6 +96,7 @@ router.post("/:user_id/groups/:group_id", async function (req, res, next) {
         $push: {
           groups: [
             {
+              groupName: group.name,
               groupId,
               status: "PENDING",
             },

--- a/routes/users.js
+++ b/routes/users.js
@@ -112,12 +112,10 @@ router.post("/:user_id/groups/:group_id", async function (req, res, next) {
 router.post(
   "/:user_id/groups/:group_id/:applicant_id",
   async function (req, res, next) {
-    const { user_id, group_id, applicant_id } = req.params;
+    const { group_id, applicant_id } = req.params;
     const resultStatus = req.body.status;
 
     try {
-      await User.findById(user_id);
-
       await User.updateOne(
         {
           _id: applicant_id,
@@ -127,7 +125,7 @@ router.post(
       );
 
       if (resultStatus === "PARTICIPATING") {
-        await Group.findOneAndUpdate(
+        Group.findOneAndUpdate(
           { _id: group_id },
           { $push: { members: applicant_id } },
           (err, data) => {
@@ -139,7 +137,7 @@ router.post(
         );
       }
 
-      await Group.findOneAndUpdate(
+      Group.findOneAndUpdate(
         { _id: group_id },
         { $pull: { applicants: applicant_id } },
         (err, data) => {

--- a/routes/users.js
+++ b/routes/users.js
@@ -110,9 +110,9 @@ router.post("/:user_id/groups/:group_id", async function (req, res, next) {
 });
 
 router.post(
-  "/:user_id/groups/:group_id/:applicants_id",
+  "/:user_id/groups/:group_id/:applicant_id",
   async function (req, res, next) {
-    const { user_id, group_id, applicants_id } = req.params;
+    const { user_id, group_id, applicant_id } = req.params;
     const resultStatus = req.body.status;
 
     try {
@@ -120,7 +120,7 @@ router.post(
 
       await User.updateOne(
         {
-          _id: applicants_id,
+          _id: applicant_id,
           "groups.groupId": group_id,
         },
         { $set: { "groups.$.status": resultStatus } }
@@ -129,7 +129,7 @@ router.post(
       if (resultStatus === "PARTICIPATING") {
         await Group.findOneAndUpdate(
           { _id: group_id },
-          { $push: { members: applicants_id } },
+          { $push: { members: applicant_id } },
           (err, data) => {
             if (err) {
               console.error(err);
@@ -141,7 +141,7 @@ router.post(
 
       await Group.findOneAndUpdate(
         { _id: group_id },
-        { $pull: { applicants: applicants_id } },
+        { $pull: { applicants: applicant_id } },
         (err, data) => {
           if (err) {
             console.error(err);


### PR DESCRIPTION
1. 로그아웃 API
2. admin 그룹관리
[role이 admin인 user 기준]

요청 status에 따라
(수락)
user: user의 group 중 요청 group과 같은 곳의 status 변경 (pending삭제, participating추가)
group: applicants삭제, member추가

(거절)
user: user의 group 중 요청 group과 같은 곳의 status 변경 (pending삭제, rejected추가)
group: applicants삭제